### PR TITLE
Rename to avoid crates.io clash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
-name = "idea"
+name = "idears"
 version = "0.1.0"
 dependencies = [
  "inquire",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "idea"
+name = "idears"
 version = "0.1.0"
 edition = "2024"
 authors = ["Youcef Kadri <youcef.d.kadri@gmail.com>"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::io::Error;
 
-use idea::{config, ideas};
+use idears::{config, ideas};
 
 fn main() -> Result<(), Error> {
     config::setup::setup()?;


### PR DESCRIPTION
### Summary
<!-- A summary of changes in this PR (e.g. "Allow excluding strings in search" -->
Rename the executable to `idears`

### Reasoning
<!-- Why was this change needed? Link to issues if needs be -->
`idea` is already taken on `crates.io`

### Changes
<!-- A more detailed list of changes, including affected functions etc. -->

